### PR TITLE
bump canvas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "q": "1.0.1",
         "lodash": "2.4.1",
-        "canvas": "1.1.6",
+        "canvas": "1.2.9",
         "canvg": "^0.0.6",
         "geopattern": "1.2.3"
     },


### PR DESCRIPTION
I kept getting canvas package build error on install but bumping the version resulted in a clean install. Am using iojs@2.3.4 btw. cheers.