### PR TITLE
Updated canvas dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "q": "1.0.1",
         "lodash": "2.4.1",
-        "canvas": "1.1.6",
+        "canvas": "^1.3.9",
         "canvg": "^0.0.6",
         "geopattern": "1.2.3"
     },


### PR DESCRIPTION
node-canvas 1.1.6 is not compatible with Node.js 4.2.6, making it impossible to generate locally newer versions of the books. Could you be able to accept it and publish a new version on npm?