### PR TITLE
Use dependency ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "dependencies": {
         "q": "^1.4.1",
         "lodash": "^4.5.0",
-        "canvas": "1.3.10",
+        "canvas": "^1.3.10",
         "canvg": "^0.0.8",
-        "geopattern": "1.2.3"
+        "geopattern": "^1.2.3"
     },
     "devDependencies": {
-        "mocha": "2.3.3"
+        "mocha": "^2.3.3"
     },
     "homepage": "https://github.com/GitbookIO/plugin-autocover",
     "repository": {


### PR DESCRIPTION
It's not good to use fixed version on dependencies of a library, since it can cause conflicts with other ones.