### PR TITLE
Add background color support to default template.

### DIFF
--- a/lib/draw.js
+++ b/lib/draw.js
@@ -19,7 +19,7 @@ module.exports = function(output, options) {
     // Default options
     //
 
-    options = _.defaults(options || {}, {
+    options = _.defaultsDeep(options || {}, {
         "title": "",
         "author": "",
         "font": {

--- a/templates/default.svg
+++ b/templates/default.svg
@@ -5,6 +5,11 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
 
+  <rect
+    fill="<%= background.color %>"
+    height="100%"
+    width="100%"/>
+
   <text
     y="10%"
     text-anchor="middle"


### PR DESCRIPTION
The README documents support for changing settings like background color, which required two changes:

- Using `_.defaultsDeep` in place of `_.defaults` to merge nested settings.
- Adding a full-size `<rect>` to render the configured background color in the default template.